### PR TITLE
Updated hotkeys to piggyback vanilla zoom keys

### DIFF
--- a/prototypes/hotkeys.lua
+++ b/prototypes/hotkeys.lua
@@ -2,11 +2,15 @@ data:extend({
   {
     type = "custom-input",
     name = "infinizoom_increase_zoom",
-    key_sequence = "CONTROL + K",
+    key_sequence = "",
+    linked_game_control = "zoom-in",
+    consuming = "game-only",
   },
   {
     type = "custom-input",
     name = "infinizoom_decrease_zoom",
-    key_sequence = "CONTROL + L",
+    key_sequence = "",
+    linked_game_control = "zoom-out",
+    consuming = "game-only",
   }
 })


### PR DESCRIPTION
Changed the hotkeys to piggyback and consume the vanilla zoom controls (scroll wheel up and down). This means they use the same button that the player has set for zoom-in and zoom-out in the base game.  This means they can use the scroll wheel and should be more intuitive for users.