### PR TITLE
Add Ctrl+O for resetting zoom

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -3,25 +3,30 @@ if zoom == nil then
 end
 
 
-function zoom_in(event)
+local function zoom_in(event)
 	local p_idx = event.player_index
 	if zoom[p_idx] == nil then
 		zoom[p_idx] = 1
-		return
 	end
 	zoom[p_idx]  = zoom[p_idx] * 1.1
 	game.players[p_idx].zoom = zoom[p_idx]
 end
 
-function zoom_out(event)
+local function zoom_out(event)
 	local p_idx = event.player_index
 	if zoom[p_idx] == nil then
 		zoom[p_idx] = 1
-		return
 	end
 	zoom[p_idx]  = zoom[p_idx] * 0.9
 	game.players[p_idx].zoom = zoom[p_idx]
 end
 
+local function zoom_reset(event)
+	local p_idx = event.player_index
+	zoom[p_idx] = 1
+	game.players[p_idx].zoom = zoom[p_idx]
+end
+
 script.on_event("infinizoom_increase_zoom", zoom_in)
 script.on_event("infinizoom_decrease_zoom", zoom_out)
+script.on_event("infinizoom_reset_zoom", zoom_reset)

--- a/prototypes/hotkeys.lua
+++ b/prototypes/hotkeys.lua
@@ -8,5 +8,10 @@ data:extend({
     type = "custom-input",
     name = "infinizoom_decrease_zoom",
     key_sequence = "CONTROL + L",
+  },
+  {
+    type = "custom-input",
+    name = "infinizoom_reset_zoom",
+    key_sequence = "CONTROL + O",
   }
 })


### PR DESCRIPTION
Since game.players[p_idx].zoom is write only, the zoom value inside this mod may differ from that inside the game. It is confusing sometimes after using both Ctrl+K/L and mouse scroll.
